### PR TITLE
Set `developmentDependency` to prevent dependency when using `nuget pack`

### DIFF
--- a/IFluentInterface.nuspec
+++ b/IFluentInterface.nuspec
@@ -13,6 +13,7 @@
 		<authors>Daniel Cazzulino</authors>
 		<owners>clariuslabs, danielkzu</owners>
 		<language>en-US</language>
+		<developmentDependency>true</developmentDependency>
 		<projectUrl>http://clarius.to/IFluentInterface</projectUrl>
 		<licenseUrl>https://github.com/clariuslabs/IFluentInterface/blob/master/LICENSE</licenseUrl>
 		<iconUrl>https://raw.github.com/clariuslabs/IFluentInterface/master/images/icon-32.png</iconUrl>


### PR DESCRIPTION
This will set `developmentDependency="true"` in **packages.config** and prevent the package to be marked as a dependency when using **nuget pack**. See [nuspec reference](http://docs.nuget.org/docs/reference/nuspec-reference).
