### PR TITLE
Added info on Resharper configuration

### DIFF
--- a/content/IFluentInterface.cs.pp
+++ b/content/IFluentInterface.cs.pp
@@ -29,6 +29,7 @@ namespace $rootnamespace$
     /// <list type = "number">
     ///   <item>When referencing the interface from within the same solution (project reference), you will still see the methods this interface is meant to hide.</item>
     ///   <item>When referencing the interface through the compiled output assembly (external reference), the standard Object methods will be hidden as intended.</item>
+    ///   <item>When using Resharper, be sure to configure it to respect the attribute: Options, go to Environment | IntelliSense | Completion Appearance and check "Filter members by [EditorBrowsable] attribute".</item>
     /// </list>
     /// See http://clarius.to/IFluentInterface for more information.
     /// </remarks>


### PR DESCRIPTION
When using Resharper, you always see them all, even when creating a separate project and referencing this. It turns out you need to tell Resharper to respect the attribute, added it to the information to save others from wasting time in the future.
