### PR TITLE
updated usings with a global:: prefix

### DIFF
--- a/build/IFluentInterface.cs.pp
+++ b/build/IFluentInterface.cs.pp
@@ -18,8 +18,8 @@
 
 namespace $rootnamespace$
 {
-    using System;
-    using System.ComponentModel;
+    using global::System;
+    using global::System.ComponentModel;
 
     /// <summary>
     /// Interface that is used to build fluent interfaces by hiding methods declared by <see cref="object"/> from IntelliSense.


### PR DESCRIPTION
To avoid namespace collision when declaring a System namespace into a project.

(cf. https://github.com/kzu/IFluentInterface/issues/3 )